### PR TITLE
feat : 사용자 주문 로그 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/forusmarket/domain/log/controller/OrderLogController.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/controller/OrderLogController.java
@@ -1,0 +1,26 @@
+package com.sparta.forusmarket.domain.log.controller;
+
+import com.sparta.forusmarket.common.response.ApiPageResponse;
+import com.sparta.forusmarket.domain.log.dto.response.OrderLogResponse;
+import com.sparta.forusmarket.domain.log.service.OrderLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderLogController {
+
+    private final OrderLogService orderLogService;
+
+    @GetMapping("/api/v1/orderlogs/{userId}")
+    public ResponseEntity<ApiPageResponse<OrderLogResponse>> getUserLogs(
+            @PathVariable Long userId,
+            Pageable pageable
+    ){
+        return orderLogService.getUserLogs(userId, pageable);
+    }
+}

--- a/src/main/java/com/sparta/forusmarket/domain/log/dto/response/OrderLogResponse.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/dto/response/OrderLogResponse.java
@@ -18,7 +18,7 @@ public class OrderLogResponse {
     private BigDecimal price;
     private LogStatus status;
     private String message;
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     public static OrderLogResponse from(OrderLog log) {
         return new OrderLogResponse(

--- a/src/main/java/com/sparta/forusmarket/domain/log/repository/OrderLogRepository.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/repository/OrderLogRepository.java
@@ -3,7 +3,12 @@ package com.sparta.forusmarket.domain.log.repository;
 import com.sparta.forusmarket.domain.log.entity.OrderLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface OrderLogRepository extends JpaRepository<OrderLog, Long> {
+
+    Page<OrderLog> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/forusmarket/domain/log/service/OrderLogService.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/service/OrderLogService.java
@@ -1,7 +1,12 @@
 package com.sparta.forusmarket.domain.log.service;
 
+import com.sparta.forusmarket.common.response.ApiPageResponse;
+import com.sparta.forusmarket.domain.log.dto.response.OrderLogResponse;
 import com.sparta.forusmarket.domain.log.entity.OrderLog;
 import com.sparta.forusmarket.domain.log.repository.OrderLogRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,5 +20,13 @@ public class OrderLogService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveLog(OrderLog orderLog) {
         orderLogRepository.save(orderLog);
+    }
+
+    public ResponseEntity<ApiPageResponse<OrderLogResponse>> getUserLogs(Long userId, Pageable pageable){
+        Page<OrderLogResponse> page = orderLogRepository
+                .findByUserIdOrderByCreatedAtDesc(userId, pageable)
+                .map(OrderLogResponse::from);
+
+        return ApiPageResponse.success(page);
     }
 }


### PR DESCRIPTION
## 🤷 어떤 기능을 개발해야 하나요?
> 사용자 주문 로그 조회 API 개발 (페이지네이션 + 공통 응답 포맷 적용)

<br>

## 🤔 이 기능의 목표는 무엇인가요?
> (사용자는 자신의 주문 성공/실패/취소 로그 이력을 시간순으로 조회할 수 있다.
> 이를 통해 주문 내역을 추적하고 실패/취소 사유를 확인할 수 있다.

<br>

## 📝 상세 작업 내용 (To-Do List)
- [x] Repository: findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable) → Page<OrderLog> 반환
- [x] Service: Page<OrderLogResponse>로 매핑 후 ApiPageResponse.success(page) 반환
- [x] Controller: GET /api/v1/users/{userId}/logs 엔드포인트 추가
- [x] 응답 구조: ApiPageResponse<T> 형태(page, size, totalPages, totalElements, data[])
- [x] 정렬 기본값: createdAt DESC, id DESC 적용

<br>

## ✅ 참고 사항
> 