### PR TITLE
feat : 사용자 주문 로그 조회 캐싱 적용

### DIFF
--- a/src/main/java/com/sparta/forusmarket/common/config/CachingConfig.java
+++ b/src/main/java/com/sparta/forusmarket/common/config/CachingConfig.java
@@ -1,8 +1,5 @@
 package com.sparta.forusmarket.common.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/sparta/forusmarket/common/config/RedisConfig.java
+++ b/src/main/java/com/sparta/forusmarket/common/config/RedisConfig.java
@@ -1,7 +1,5 @@
 package com.sparta.forusmarket.common.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/sparta/forusmarket/common/config/RedisConfig.java
+++ b/src/main/java/com/sparta/forusmarket/common/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.sparta.forusmarket.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,7 +9,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -30,7 +32,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/com/sparta/forusmarket/common/response/ApiPageResponse.java
+++ b/src/main/java/com/sparta/forusmarket/common/response/ApiPageResponse.java
@@ -1,19 +1,27 @@
 package com.sparta.forusmarket.common.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
-public class ApiPageResponse<T> {
+@NoArgsConstructor
+public class ApiPageResponse<T> implements Serializable {
 
-    private final int page;
-    private final int size;
-    private final int totalPages;
-    private final long totalElements;
-    private final List<T> data;
+    private int page;
+    private int size;
+    private int totalPages;
+    private long totalElements;
+    private List<T> data;
 
     private ApiPageResponse(int page, int size, int totalPages, long totalElements, List<T> data) {
         this.page = page;
@@ -24,14 +32,27 @@ public class ApiPageResponse<T> {
     }
 
     /**
-     * 성공적인 요청에 대한 페이징 응답을 반환하는 메서드
-     * 주어진 데이터를 포함하여 HTTP 200 OK 상태 코드와 함께 응답을 반환
+     * 성공적인 요청에 대한 페이징 응답을 반환하는 메서드 주어진 데이터를 포함하여 HTTP 200 OK 상태 코드와 함께 응답을 반환
      *
      * @param pagedData 요청 성공 시 반환할 페이징 데이터
      * @return HTTP 200 OK 응답과 함께 성공 데이터가 포함된 ApiPageResponse
      */
+    public static <T> ResponseEntity<ApiPageResponse<T>> success(RestPage<T> pagedData) {
+        return ResponseEntity.ok(fromPage(pagedData));
+    }
+
     public static <T> ResponseEntity<ApiPageResponse<T>> success(Page<T> pagedData) {
         return ResponseEntity.ok(fromPage(pagedData));
+    }
+
+    private static <T> ApiPageResponse<T> fromPage(RestPage<T> pagedData) {
+        return new ApiPageResponse<>(
+                pagedData.getPageable().getPageNumber(),
+                pagedData.getPageable().getPageSize(),
+                pagedData.getTotalPages(),
+                pagedData.getTotalElements(),
+                pagedData.getContent()
+        );
     }
 
     private static <T> ApiPageResponse<T> fromPage(Page<T> pagedData) {
@@ -42,5 +63,20 @@ public class ApiPageResponse<T> {
                 pagedData.getTotalElements(),
                 pagedData.getContent()
         );
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+    public static class RestPage<T> extends PageImpl<T> {
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public RestPage(@JsonProperty("content") List<T> content,
+                        @JsonProperty("number") int page,
+                        @JsonProperty("size") int size,
+                        @JsonProperty("totalElements") long total) {
+            super(content, PageRequest.of(page, size), total);
+        }
+
+        public RestPage(Page<T> page) {
+            super(page.getContent(), page.getPageable(), page.getTotalElements());
+        }
     }
 }

--- a/src/main/java/com/sparta/forusmarket/common/response/RestPage.java
+++ b/src/main/java/com/sparta/forusmarket/common/response/RestPage.java
@@ -1,0 +1,26 @@
+package com.sparta.forusmarket.common.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") List<T> content,
+                    @JsonProperty("number") int page,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") long total) {
+        super(content, PageRequest.of(page, size), total);
+    }
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}
+

--- a/src/main/java/com/sparta/forusmarket/common/response/RestPage.java
+++ b/src/main/java/com/sparta/forusmarket/common/response/RestPage.java
@@ -23,4 +23,3 @@ public class RestPage<T> extends PageImpl<T> {
         super(page.getContent(), page.getPageable(), page.getTotalElements());
     }
 }
-

--- a/src/main/java/com/sparta/forusmarket/domain/log/controller/OrderLogController.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/controller/OrderLogController.java
@@ -1,9 +1,11 @@
 package com.sparta.forusmarket.domain.log.controller;
 
 import com.sparta.forusmarket.common.response.ApiPageResponse;
+import com.sparta.forusmarket.common.response.RestPage;
 import com.sparta.forusmarket.domain.log.dto.response.OrderLogResponse;
 import com.sparta.forusmarket.domain.log.service.OrderLogService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,11 +18,22 @@ public class OrderLogController {
 
     private final OrderLogService orderLogService;
 
+    // 캐싱 x
     @GetMapping("/api/v1/orderlogs/{userId}")
     public ResponseEntity<ApiPageResponse<OrderLogResponse>> getUserLogs(
             @PathVariable Long userId,
             Pageable pageable
     ){
         return orderLogService.getUserLogs(userId, pageable);
+    }
+
+    // 캐싱 o
+    @GetMapping("/api/v2/orderlogs/{userId}")
+    public ResponseEntity<ApiPageResponse<OrderLogResponse>> getCachedUserLogs(
+            @PathVariable Long userId,
+            Pageable pageable
+    ){
+        RestPage<OrderLogResponse> page = orderLogService.getCachedUserLogs(userId, pageable);
+        return ApiPageResponse.success(page);
     }
 }

--- a/src/main/java/com/sparta/forusmarket/domain/log/dto/response/OrderLogResponse.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/dto/response/OrderLogResponse.java
@@ -8,12 +8,14 @@ import com.sparta.forusmarket.domain.log.entity.OrderLog;
 import com.sparta.forusmarket.domain.log.enums.LogStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class OrderLogResponse {
     private Long id;
     private Long orderId;

--- a/src/main/java/com/sparta/forusmarket/domain/log/dto/response/OrderLogResponse.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/dto/response/OrderLogResponse.java
@@ -1,5 +1,9 @@
 package com.sparta.forusmarket.domain.log.dto.response;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.sparta.forusmarket.domain.log.entity.OrderLog;
 import com.sparta.forusmarket.domain.log.enums.LogStatus;
 import lombok.AllArgsConstructor;
@@ -18,6 +22,9 @@ public class OrderLogResponse {
     private BigDecimal price;
     private LogStatus status;
     private String message;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
     public static OrderLogResponse from(OrderLog log) {

--- a/src/main/java/com/sparta/forusmarket/domain/log/repository/OrderLogRepository.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/repository/OrderLogRepository.java
@@ -3,12 +3,8 @@ package com.sparta.forusmarket.domain.log.repository;
 import com.sparta.forusmarket.domain.log.entity.OrderLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface OrderLogRepository extends JpaRepository<OrderLog, Long> {
-
     Page<OrderLog> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/forusmarket/domain/log/service/OrderLogService.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/service/OrderLogService.java
@@ -8,6 +8,7 @@ import com.sparta.forusmarket.domain.log.repository.OrderLogRepository;
 import com.sparta.forusmarket.domain.product.dto.response.ProductResponse;
 import com.sparta.forusmarket.domain.product.entity.Product;
 import com.sparta.forusmarket.domain.product.type.SubCategoryType;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,22 +26,26 @@ public class OrderLogService {
     private final OrderLogRepository orderLogRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
+    // 로그 저장
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @CacheEvict(cacheNames = "order:log", allEntries = true, beforeInvocation = true)
     public void saveLog(OrderLog orderLog) {
         orderLogRepository.save(orderLog);
     }
 
-    // 캐싱 x
+    // 캐싱 X
     public ResponseEntity<ApiPageResponse<OrderLogResponse>> getUserLogs(Long userId, Pageable pageable){
         Page<OrderLogResponse> page = orderLogRepository
                 .findByUserIdOrderByCreatedAtDesc(userId, pageable)
                 .map(OrderLogResponse::from);
-
         return ApiPageResponse.success(page);
     }
 
-    // 캐싱 o
-    @Cacheable(value = "order", key = "'all'")
+    // 캐싱 O
+    @Cacheable(
+            cacheNames = "order:log",
+            key = "#userId + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + #pageable.sort"
+    )
     public RestPage<OrderLogResponse> getCachedUserLogs(Long userId, Pageable pageable){
         Page<OrderLog> log = orderLogRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
         return new RestPage<>(log.map(OrderLogResponse::from));

--- a/src/main/java/com/sparta/forusmarket/domain/log/service/OrderLogService.java
+++ b/src/main/java/com/sparta/forusmarket/domain/log/service/OrderLogService.java
@@ -1,11 +1,17 @@
 package com.sparta.forusmarket.domain.log.service;
 
 import com.sparta.forusmarket.common.response.ApiPageResponse;
+import com.sparta.forusmarket.common.response.RestPage;
 import com.sparta.forusmarket.domain.log.dto.response.OrderLogResponse;
 import com.sparta.forusmarket.domain.log.entity.OrderLog;
 import com.sparta.forusmarket.domain.log.repository.OrderLogRepository;
+import com.sparta.forusmarket.domain.product.dto.response.ProductResponse;
+import com.sparta.forusmarket.domain.product.entity.Product;
+import com.sparta.forusmarket.domain.product.type.SubCategoryType;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,19 +20,29 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderLogService {
     private final OrderLogRepository orderLogRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveLog(OrderLog orderLog) {
         orderLogRepository.save(orderLog);
     }
 
+    // 캐싱 x
     public ResponseEntity<ApiPageResponse<OrderLogResponse>> getUserLogs(Long userId, Pageable pageable){
         Page<OrderLogResponse> page = orderLogRepository
                 .findByUserIdOrderByCreatedAtDesc(userId, pageable)
                 .map(OrderLogResponse::from);
 
         return ApiPageResponse.success(page);
+    }
+
+    // 캐싱 o
+    @Cacheable(value = "order", key = "'all'")
+    public RestPage<OrderLogResponse> getCachedUserLogs(Long userId, Pageable pageable){
+        Page<OrderLog> log = orderLogRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        return new RestPage<>(log.map(OrderLogResponse::from));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
<!---- 
기존 사용자 주문 로그 조회 API에 캐싱 적용
-->

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #44 -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외
